### PR TITLE
remove `url` field from git-extras manifest

### DIFF
--- a/bundles/sourcegraph-git-extras/package.json
+++ b/bundles/sourcegraph-git-extras/package.json
@@ -162,6 +162,5 @@
     "author"
   ],
   "title": "Git extras",
-  "url": "https://sourcegraph.com/-/static/extension/16312-sourcegraph-git-extras.js?cmlqbmpj8ob4--sourcegraph-git-extras",
   "version": "0.0.0-DEVELOPMENT"
 }


### PR DESCRIPTION
Fixes loading patched `sourcegraph/git-extras` extension bundle for pre-4.0 Sourcegraph instances.
Follow-up on https://github.com/sourcegraph/sourcegraph-extensions-bundles/pull/5

#### Note on implementation

The latest `sourcegraph/git-extras` bundle is not published to the remote extension registry. The included bundle (_bundles/sourcegraph-git-extras_) was generated from [sourcegraph/sourcegraph-git-extras](https://github.com/sourcegraph/sourcegraph-git-extras) repo (more details in https://github.com/sourcegraph/sourcegraph-extensions-bundles/pull/5 description).
`sourcegraph/git-extras` manifest has `url` field so that the extension bundle can be preloaded by the Sourcegraph web app ([SourcegraphWebApp](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@f659e618d762f8fd7a8636dbfa60de63e58f2814/-/blob/client/web/src/SourcegraphWebApp.tsx?L213) ➡️  [preloadExtensions](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@f659e618d762f8fd7a8636dbfa60de63e58f2814/-/blob/client/shared/src/api/client/preload.ts?L28) ➡️  [getScriptURLFromExtensionManifest](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@f659e618d762f8fd7a8636dbfa60de63e58f2814/-/blob/client/shared/src/extensions/extension.ts?L94)). This file points to the latest extension bundle _on the remote extensions registry_, which is outdated in our case.
The suggested fix is to remove the `url` field from extension manifest so that app loads the local bundle (_bundles/sourcegraph-git-extras/sourcegraph-git-extras.js_) instead of (pre-)loading the 'outdated' one from the remote registry.
